### PR TITLE
Fix custom defines

### DIFF
--- a/src/c/tests/functions/function_internal/config.json
+++ b/src/c/tests/functions/function_internal/config.json
@@ -3,6 +3,10 @@
   "userIncludeDirectories": [
     "../../../production/ffi_helper/include"
   ],
+  "defines": {
+    "BAD_CUSTOM_API_DECL": "extern",
+    "GOOD_CUSTOM_API_DECL": "extern __attribute__ ((visibility(\"default\")))"
+  },
   "ignoredIncludeFiles": [
     "../../../production/ffi_helper/include/ffi_helper.h"
   ],

--- a/src/c/tests/functions/function_internal/main.c
+++ b/src/c/tests/functions/function_internal/main.c
@@ -1,6 +1,22 @@
 #include <stdio.h>
 #include "ffi_helper.h"
 
-void function_internal()
+void function_internal_1()
+{
+}
+
+FFI_API_DECL void function_internal_2()
+{
+}
+
+UNKNOWN_CUSTOM_API_DECL void function_internal_3()
+{
+}
+
+BAD_CUSTOM_API_DECL void function_internal_4()
+{
+}
+
+GOOD_CUSTOM_API_DECL void function_internal_5()
 {
 }

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/Explorer.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/Explorer.cs
@@ -9,6 +9,7 @@ using c2ffi.Tool.Commands.Extract.Domain.Parse;
 using c2ffi.Tool.Commands.Extract.Infrastructure.Clang;
 using c2ffi.Tool.Commands.Extract.Input.Sanitized;
 using c2ffi.Tool.Internal;
+using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 
 namespace c2ffi.Tool.Commands.Extract.Domain.Explore;
@@ -129,8 +130,14 @@ public sealed partial class Explorer
 
     private void VisitInclude(ExploreContext context, clang.CXCursor clangCursor)
     {
-        var file = clang.clang_getIncludedFile(clangCursor);
-        var filePath = Path.GetFullPath(clang.clang_getFileName(file).String());
+        var clangFile = clang.clang_getIncludedFile(clangCursor);
+        var stringFile = clang.clang_getFileName(clangFile).String();
+        if (string.IsNullOrEmpty(stringFile))
+        {
+            return;
+        }
+
+        var filePath = Path.GetFullPath(stringFile);
         foreach (var systemIncludeDirectory in context.ParseContext.SystemIncludeDirectories)
         {
             if (filePath.Contains(systemIncludeDirectory, StringComparison.InvariantCulture))

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Parse/ParseArgumentsProvider.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Parse/ParseArgumentsProvider.cs
@@ -106,16 +106,16 @@ public sealed class ParseArgumentsProvider
         }
     }
 
-    private void AddDefines(ImmutableArray<string>.Builder args, ImmutableArray<string> defines)
+    private void AddDefines(ImmutableArray<string>.Builder args, ImmutableDictionary<string, string> defines)
     {
-        if (defines.IsDefaultOrEmpty)
+        if (defines.IsEmpty)
         {
             return;
         }
 
-        foreach (var defineMacro in defines)
+        foreach (var (key, value) in defines)
         {
-            var commandLineArg = "--define-macro=" + defineMacro;
+            var commandLineArg = $"-D{key}={value}";
             args.Add(commandLineArg);
         }
     }

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/ExtractInputSanitizer.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/ExtractInputSanitizer.cs
@@ -122,7 +122,7 @@ public sealed class ExtractInputSanitizer : InputSanitizer<UnsanitizedExtractInp
             SystemIncludeDirectories = SystemIncludeDirectories(input, targetPlatformInput),
             UserIncludeDirectories = UserIncludeDirectories(input, targetPlatformInput, inputFilePath),
             IgnoredIncludeFiles = IgnoredIncludeFiles(input, targetPlatformInput),
-            MacroObjectDefines = ClangDefines(targetPlatformInput),
+            MacroObjectDefines = ClangDefines(input, targetPlatformInput),
             AdditionalArguments = ClangArguments(targetPlatformInput),
             IsEnabledFindSystemHeaders = input.IsEnabledAutomaticallyFindSystemHeaders ?? true,
             IsEnabledSystemDeclarations = input.IsEnabledSystemDeclarations ?? false,
@@ -169,9 +169,11 @@ public sealed class ExtractInputSanitizer : InputSanitizer<UnsanitizedExtractInp
             input.IgnoredIncludeFiles, targetPlatformInput.IgnoredIncludeDirectories);
     }
 
-    private ImmutableArray<string> ClangDefines(UnsanitizedExtractInputTargetPlatform targetPlatformInput)
+    private ImmutableDictionary<string, string> ClangDefines(
+        UnsanitizedExtractInput input,
+        UnsanitizedExtractInputTargetPlatform targetPlatformInput)
     {
-        return SanitizeStrings(targetPlatformInput.Defines);
+        return SanitizeStringsAndCombine(input.Defines, targetPlatformInput.Defines);
     }
 
     private ImmutableArray<string> ClangArguments(UnsanitizedExtractInputTargetPlatform targetPlatformInput)

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Sanitized/ExtractTargetPlatformOptions.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Sanitized/ExtractTargetPlatformOptions.cs
@@ -18,7 +18,7 @@ public sealed class ExtractTargetPlatformOptions
 
     public ImmutableArray<string> IgnoredIncludeFiles { get; init; } = ImmutableArray<string>.Empty;
 
-    public ImmutableArray<string> MacroObjectDefines { get; init; } = ImmutableArray<string>.Empty;
+    public ImmutableDictionary<string, string> MacroObjectDefines { get; init; } = ImmutableDictionary<string, string>.Empty;
 
     public ImmutableArray<string> AdditionalArguments { get; init; } = ImmutableArray<string>.Empty;
 

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInput.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInput.cs
@@ -42,6 +42,12 @@ public sealed class UnsanitizedExtractInput
     public ImmutableArray<string>? SystemIncludeDirectories { get; set; }
 
     /// <summary>
+    ///     Gets or sets the object-like macros to use when parsing C code.
+    /// </summary>
+    [JsonPropertyName("defines")]
+    public ImmutableDictionary<string, string>? Defines { get; set; }
+
+    /// <summary>
     ///     Gets or sets the directories to ignore header files.
     /// </summary>
     [JsonPropertyName("ignoredIncludeFiles")]

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInputTargetPlatform.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInputTargetPlatform.cs
@@ -33,7 +33,7 @@ public sealed class UnsanitizedExtractInputTargetPlatform
     ///     Gets or sets the object-like macros to use when parsing C code.
     /// </summary>
     [JsonPropertyName("defines")]
-    public ImmutableArray<string>? Defines { get; set; }
+    public ImmutableDictionary<string, string>? Defines { get; set; }
 
     /// <summary>
     ///     Gets or sets the additional Clang arguments to use when parsing C code.

--- a/src/cs/production/c2ffi.Tool/Internal/Input/InputSanitizer.cs
+++ b/src/cs/production/c2ffi.Tool/Internal/Input/InputSanitizer.cs
@@ -82,6 +82,27 @@ public abstract class InputSanitizer<TUnsanitizedInput, TSanitizedInput>
         return result;
     }
 
+    protected ImmutableDictionary<string, string> SanitizeStrings(ImmutableDictionary<string, string>? strings)
+    {
+        if (strings == null || strings.IsEmpty)
+        {
+            return ImmutableDictionary<string, string>.Empty;
+        }
+
+        var result = strings.Where(x => !string.IsNullOrEmpty(x.Key) && !string.IsNullOrEmpty(x.Value)).ToImmutableDictionary();
+        return result;
+    }
+
+    protected ImmutableDictionary<string, string> SanitizeStringsAndCombine(
+        ImmutableDictionary<string, string>? strings1,
+        ImmutableDictionary<string, string>? strings2)
+    {
+        var sanitizedStrings1 = SanitizeStrings(strings1);
+        var sanitizedStrings2 = SanitizeStrings(strings2);
+        var result = sanitizedStrings1.AddRange(sanitizedStrings2);
+        return result;
+    }
+
     protected ImmutableArray<string> SanitizeDirectoryPaths(
         ImmutableArray<string>? directoryPaths1,
         ImmutableArray<string>? directoryPaths2 = null)

--- a/src/cs/tests/c2ffi.Tests.EndToEnd.Merge/Functions/function_internal/Test.cs
+++ b/src/cs/tests/c2ffi.Tests.EndToEnd.Merge/Functions/function_internal/Test.cs
@@ -3,57 +3,54 @@
 
 using c2ffi.Tests.Library.Models;
 using FluentAssertions;
+using Xunit;
 
 #pragma warning disable CA1707
 
-namespace c2ffi.Tests.EndToEnd.Extract.Functions.function_internal;
+namespace c2ffi.Tests.EndToEnd.Merge.Functions.function_internal;
 
-public class Test : ExtractFfiTest
+public class Test : MergeFfisTest
 {
     private const string FunctionName = "function_internal";
 
     [Fact]
     public void Function()
     {
-        var ffis = GetTargetPlatformFfis(
-            $"src/c/tests/functions/{FunctionName}/config.json");
-        Assert.True(ffis.Length > 0);
+        var ffi = GetCrossPlatformFfi(
+            $"src/c/tests/functions/{FunctionName}/ffi");
 
-        foreach (var ffi in ffis)
-        {
-            Function1DoesNotExist(ffi);
-            Function2DoesExist(ffi);
-            Function3DoesNotExist(ffi);
-            Function4DoesNotExist(ffi);
-            Function5DoesExist(ffi);
-        }
+        Function1DoesNotExist(ffi);
+        Function2DoesExist(ffi);
+        Function3DoesNotExist(ffi);
+        Function4DoesNotExist(ffi);
+        Function5DoesExist(ffi);
     }
 
-    private void Function1DoesNotExist(CTestFfiTargetPlatform ffi)
+    private void Function1DoesNotExist(CTestFfiCrossPlatform ffi)
     {
         var function = ffi.TryGetFunction("function_internal_1");
         function.Should().BeNull();
     }
 
-    private void Function2DoesExist(CTestFfiTargetPlatform ffi)
+    private void Function2DoesExist(CTestFfiCrossPlatform ffi)
     {
         var function = ffi.TryGetFunction("function_internal_2");
         function.Should().NotBeNull();
     }
 
-    private void Function3DoesNotExist(CTestFfiTargetPlatform ffi)
+    private void Function3DoesNotExist(CTestFfiCrossPlatform ffi)
     {
         var function = ffi.TryGetFunction("function_internal_3");
         function.Should().BeNull();
     }
 
-    private void Function4DoesNotExist(CTestFfiTargetPlatform ffi)
+    private void Function4DoesNotExist(CTestFfiCrossPlatform ffi)
     {
         var function = ffi.TryGetFunction("function_internal_4");
         function.Should().BeNull();
     }
 
-    private void Function5DoesExist(CTestFfiTargetPlatform ffi)
+    private void Function5DoesExist(CTestFfiCrossPlatform ffi)
     {
         var function = ffi.TryGetFunction("function_internal_5");
         function.Should().NotBeNull();


### PR DESCRIPTION
- Fixes usage of macro object defines passed to `libclang` when coming from extract JSON config file.
- Macro object defines in JSON config file are now type of `ImmutableDictionary<string, string>` instead of `ImmutableArray<string>`. The key is the name of macro object, and the value is the value of the macro object.