### PR TITLE
Explicitly include an enum by name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ obj/
 /artifacts/
 src/c/tests/**/ffi/*.json
 src/c/tests/**/ffi-x/*.json
+
+# Native library files
+lib/*.*

--- a/src/c/tests/functions/function_implicit_enum/config.json
+++ b/src/c/tests/functions/function_implicit_enum/config.json
@@ -1,0 +1,30 @@
+{
+  "inputFilePath": "./main.c",
+  "userIncludeDirectories": [
+    "../../../production/ffi_helper/include"
+  ],
+  "ignoredIncludeFiles": [
+    "../../../production/ffi_helper/include/ffi_helper.h"
+  ],
+  "includedNames": [
+    "enum_implicit"
+  ],
+  "targetPlatforms": {
+    "windows": {
+      "i686-pc-windows-msvc": {},
+      "x86_64-pc-windows-msvc": {},
+      "aarch64-pc-windows-msvc": {}
+    },
+    "macos": {
+      "i686-apple-darwin": {},
+      "aarch64-apple-darwin": {},
+      "x86_64-apple-darwin": {},
+      "aarch64-apple-ios": {}
+    },
+    "linux": {
+      "i686-unknown-linux-gnu": {},
+      "x86_64-unknown-linux-gnu": {},
+      "aarch64-unknown-linux-gnu": {}
+    }
+  }
+}

--- a/src/c/tests/functions/function_implicit_enum/main.c
+++ b/src/c/tests/functions/function_implicit_enum/main.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+#include "ffi_helper.h"
+
+enum enum_implicit {
+    ENUM_IMPLICIT_VALUE0 = 0,
+    ENUM_IMPLICIT_VALUE1 = 255
+} enum_implicit;
+
+FFI_API_DECL int function_implicit_enum(int value)
+{
+    return ENUM_IMPLICIT_VALUE1;
+}

--- a/src/cs/production/c2ffi.Data/Generated/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/JsonSerializerContextCFfiCrossPlatform.g.cs
+++ b/src/cs/production/c2ffi.Data/Generated/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/JsonSerializerContextCFfiCrossPlatform.g.cs
@@ -8,7 +8,7 @@
 
 namespace c2ffi.Data.Serialization
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "8.0.10.11423")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "8.0.10.31311")]
     public partial class JsonSerializerContextCFfiCrossPlatform
     {
         private readonly static global::System.Text.Json.JsonSerializerOptions s_defaultOptions = new()

--- a/src/cs/production/c2ffi.Data/Generated/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/JsonSerializerContextCFfiTargetPlatform.g.cs
+++ b/src/cs/production/c2ffi.Data/Generated/System.Text.Json.SourceGeneration/System.Text.Json.SourceGeneration.JsonSourceGenerator/JsonSerializerContextCFfiTargetPlatform.g.cs
@@ -8,7 +8,7 @@
 
 namespace c2ffi.Data.Serialization
 {
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "8.0.10.11423")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Text.Json.SourceGeneration", "8.0.10.31311")]
     public partial class JsonSerializerContextCFfiTargetPlatform
     {
         private readonly static global::System.Text.Json.JsonSerializerOptions s_defaultOptions = new()

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/Context/ExploreContext.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/Context/ExploreContext.cs
@@ -125,6 +125,24 @@ public sealed class ExploreContext : IDisposable
         ParseContext.Dispose();
     }
 
+    public string GetFieldName(clang.CXCursor clangCursor)
+    {
+        if (clangCursor.kind != clang.CXCursorKind.CXCursor_FieldDecl)
+        {
+            return string.Empty;
+        }
+
+        var name = clangCursor.Spelling();
+
+        // NOTE: In newer versions of Clang (specifically found on 18.1), getting the name of the field has changed if it anonymous. Old behavior was to return empty string.
+        if (name.Contains("::(anonymous at", StringComparison.OrdinalIgnoreCase))
+        {
+            return string.Empty;
+        }
+
+        return name;
+    }
+
     private CType VisitTypeInternal(
         CNodeKind nodeKind,
         string typeName,

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/ExploreNodeInfo.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/ExploreNodeInfo.cs
@@ -28,6 +28,16 @@ public sealed class ExploreNodeInfo
 
     public override string ToString()
     {
-        return Name;
+        if (!string.IsNullOrEmpty(Name))
+        {
+            return Name;
+        }
+
+        if (!string.IsNullOrEmpty(TypeName))
+        {
+            return TypeName;
+        }
+
+        return "???";
     }
 }

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/NodeExplorers/StructExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/NodeExplorers/StructExplorer.cs
@@ -71,7 +71,7 @@ public sealed class StructExplorer(ILogger<StructExplorer> logger) : RecordExplo
         ExploreNodeInfo structInfo,
         CXCursor clangCursor)
     {
-        var fieldName = clangCursor.Spelling();
+        var fieldName = context.GetFieldName(clangCursor);
         var clangType = clang_getCursorType(clangCursor);
         var location = context.ParseContext.Location(clangCursor);
         var type = context.VisitType(clangType, structInfo);

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/NodeExplorers/UnionExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Explore/NodeExplorers/UnionExplorer.cs
@@ -68,7 +68,7 @@ public sealed class UnionExplorer(ILogger<UnionExplorer> logger) : RecordExplore
         CXCursor clangCursor,
         ExploreNodeInfo parentInfo)
     {
-        var name = clangCursor.Spelling();
+        var name = context.GetFieldName(clangCursor);
         var clangType = clang_getCursorType(clangCursor);
         var location = context.ParseContext.Location(clangCursor);
         var type = context.VisitType(clangType, parentInfo);

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Parse/ClangTranslationUnitParser.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Domain/Parse/ClangTranslationUnitParser.cs
@@ -68,7 +68,8 @@ public sealed partial class ClangTranslationUnitParser
         ImmutableArray<string> commandLineArgs,
         out CXTranslationUnit translationUnit,
         bool skipFunctionBodies = true,
-        bool keepGoing = false)
+        bool keepGoing = false,
+        bool isSingleHeader = false)
     {
         // ReSharper disable BitwiseOperatorOnEnumWithoutFlags
         uint options = 0x0 |
@@ -78,6 +79,11 @@ public sealed partial class ClangTranslationUnitParser
                        0x2000 | // CXTranslationUnit_VisitImplicitAttributes
                        0x4000 | // CXTranslationUnit_IgnoreNonErrorsFromIncludedFiles
                        0x0;
+
+        if (isSingleHeader)
+        {
+            options |= 0x400; // CXTranslationUnit_SingleFileParse
+        }
 
         if (skipFunctionBodies)
         {

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/ExtractInputSanitizer.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/ExtractInputSanitizer.cs
@@ -126,6 +126,8 @@ public sealed class ExtractInputSanitizer : InputSanitizer<UnsanitizedExtractInp
             MacroObjectDefines = ClangDefines(input, targetPlatformInput),
             AdditionalArguments = ClangArguments(targetPlatformInput),
             IsEnabledFindSystemHeaders = input.IsEnabledAutomaticallyFindSystemHeaders ?? true,
+            IsSingleHeader = input.IsSingleHeader ?? false,
+            IncludedNames = IncludedNames(input),
             IgnoredMacroObjectsRegexes = IgnoredMacroObjects(input),
             IgnoredVariableRegexes = IgnoredVariables(input),
             IgnoredFunctionRegexes = IgnoredFunctions(input)
@@ -192,6 +194,11 @@ public sealed class ExtractInputSanitizer : InputSanitizer<UnsanitizedExtractInp
     private ImmutableArray<Regex> IgnoredFunctions(UnsanitizedExtractInput input)
     {
         return SanitizeRegexes(input.IgnoredFunctions);
+    }
+
+    private ImmutableHashSet<string> IncludedNames(UnsanitizedExtractInput input)
+    {
+        return SanitizeStrings(input.IncludedNames).ToImmutableHashSet();
     }
 
     private string SanitizeOutputDirectoryPath(

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Sanitized/ExtractTargetPlatformInput.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Sanitized/ExtractTargetPlatformInput.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Immutable;
 using System.Text.RegularExpressions;
+using bottlenoselabs;
 using c2ffi.Data;
 
 namespace c2ffi.Tool.Commands.Extract.Input.Sanitized;
@@ -24,6 +25,10 @@ public sealed class ExtractTargetPlatformInput
     public ImmutableArray<string> AdditionalArguments { get; init; } = ImmutableArray<string>.Empty;
 
     public bool IsEnabledFindSystemHeaders { get; init; }
+
+    public bool IsSingleHeader { get; init; }
+
+    public ImmutableHashSet<string> IncludedNames { get; init; } = ImmutableHashSet<string>.Empty;
 
     public ImmutableArray<Regex> IgnoredMacroObjectsRegexes { get; init; } = ImmutableArray<Regex>.Empty;
 

--- a/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInput.cs
+++ b/src/cs/production/c2ffi.Tool/Commands/Extract/Input/Unsanitized/UnsanitizedExtractInput.cs
@@ -55,45 +55,6 @@ public sealed class UnsanitizedExtractInput : ToolUnsanitizedInput
     public ImmutableArray<string>? IgnoredIncludeFiles { get; set; }
 
     /// <summary>
-    ///     Gets or sets a value that determines whether to show the the path of header code locations with full paths
-    ///     or relative paths.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Default is <c>false</c>. Use <c>true</c> to use the full path for header locations. Use <c>false</c> to
-    ///         show only relative file paths.
-    ///     </para>
-    /// </remarks>
-    [JsonPropertyName("isEnabledLocationFullPaths")]
-    public bool? IsEnabledLocationFullPaths { get; set; }
-
-    /// <summary>
-    ///     Gets or sets a value that determines whether to include or exclude declarations (functions, enums, structs,
-    ///     typedefs, etc) with a prefixed underscore that are assumed to be 'non public'.
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Default is <c>false</c>. Use <c>true</c> to include declarations with a prefixed underscore. Use
-    ///         <c>false</c> to exclude declarations with a prefixed underscore.
-    ///     </para>
-    /// </remarks>
-    [JsonPropertyName("isEnabledAllowNamesWithPrefixedUnderscore")]
-    public bool? IsEnabledAllowNamesWithPrefixedUnderscore { get; set; }
-
-    /// <summary>
-    ///     Gets or sets a value that determines whether to include or exclude system declarations (functions, enums,
-    ///     typedefs, records, etc).
-    /// </summary>
-    /// <remarks>
-    ///     <para>
-    ///         Default is `false`. Use <c>true</c> to include system declarations. Use `false` to exclude system
-    ///         declarations.
-    ///     </para>
-    /// </remarks>
-    [JsonPropertyName("isEnabledSystemDeclarations")]
-    public bool? IsEnabledSystemDeclarations { get; set; }
-
-    /// <summary>
     ///     Gets or sets a value that determines whether to automatically find and append the system headers for the
     ///     target platform.
     /// </summary>
@@ -107,15 +68,14 @@ public sealed class UnsanitizedExtractInput : ToolUnsanitizedInput
     public bool? IsEnabledAutomaticallyFindSystemHeaders { get; set; }
 
     /// <summary>
-    ///     Gets or sets determines whether to parse only the top-level cursors which are externally visible, or all
-    ///     top-level cursors.
+    ///     Gets or sets a value that determines whether the C code is parsed as a single header or multiple headers.
     /// </summary>
     /// <para>
-    ///     Default is <c>true</c>. Use <c>true</c> to parse only top-level cursors which are externally visible. Use
-    ///     <c>false</c> to parse all top-level cursors whether or not they are externally visible.
+    ///     Default is <c>false</c>. Use <c>true</c> to parse the C code as a single header. Use <c>false</c> to parse
+    ///     the C code as multiple headers.
     /// </para>
-    [JsonPropertyName("isEnabledOnlyExternalTopLevelCursors")]
-    public bool? IsEnabledOnlyExternalTopLevelCursors { get; set; }
+    [JsonPropertyName("isSingleHeader")]
+    public bool? IsSingleHeader { get; set; }
 
     /// <summary>
     ///     Gets or sets the cursor names to be treated as opaque types.
@@ -153,4 +113,10 @@ public sealed class UnsanitizedExtractInput : ToolUnsanitizedInput
     /// </summary>
     [JsonPropertyName("appleFrameworks")]
     public ImmutableArray<string>? AppleFrameworks { get; set; }
+
+    /// <summary>
+    ///     Gets or sets the name of enums that are explicitly allowed.
+    /// </summary>
+    [JsonPropertyName("includedNames")]
+    public ImmutableArray<string>? IncludedNames { get; set; }
 }

--- a/src/cs/production/c2ffi.Tool/c2ffi.Tool.csproj
+++ b/src/cs/production/c2ffi.Tool/c2ffi.Tool.csproj
@@ -52,5 +52,13 @@
     <Folder Include="Commands\Extract\Infrastructure\" />
     <Folder Include="Generated\" />
   </ItemGroup>
+  
+  <!-- libclang -->
+  <ItemGroup>
+    <None Include="$(GitRepositoryPath)\lib\libclang.dll" Condition="Exists('$(GitRepositoryPath)\lib\libclang.dll')">
+      <Link>libclang.dll</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
 </Project>

--- a/src/cs/tests/c2ffi.Tests.EndToEnd.Extract/Functions/function_implicit_enum/Test.cs
+++ b/src/cs/tests/c2ffi.Tests.EndToEnd.Extract/Functions/function_implicit_enum/Test.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Bottlenose Labs Inc. (https://github.com/bottlenoselabs). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the Git repository root directory for full license information.
+
+#pragma warning disable CA1707
+
+namespace c2ffi.Tests.EndToEnd.Extract.Functions.function_implicit_enum;
+
+public class Test : ExtractFfiTest
+{
+    private const string FunctionName = "function_implicit_enum";
+
+    [Fact]
+    public void Function()
+    {
+        var ffis = GetTargetPlatformFfis(
+            $"src/c/tests/functions/{FunctionName}/config.json");
+        Assert.True(ffis.Length > 0);
+
+        foreach (var ffi in ffis)
+        {
+            FfiFunctionExists(ffi);
+            FfiEnumExists(ffi);
+        }
+    }
+
+    private void FfiFunctionExists(CTestFfiTargetPlatform ffi)
+    {
+        var function = ffi.GetFunction(FunctionName);
+        function.CallingConvention.Should().Be("cdecl");
+
+        var returnType = function.ReturnType;
+        returnType.Name.Should().Be("int");
+        returnType.NodeKind.Should().Be("primitive");
+        returnType.SizeOf.Should().Be(4);
+        returnType.AlignOf.Should().Be(4);
+        returnType.InnerType.Should().BeNull();
+
+        function.Parameters.Should().HaveCount(1);
+        var parameter = function.Parameters[0];
+        parameter.Name.Should().Be("value");
+        parameter.Type.Name.Should().Be("int");
+        parameter.Type.NodeKind.Should().Be("primitive");
+        parameter.Type.SizeOf.Should().Be(4);
+        parameter.Type.AlignOf.Should().Be(4);
+    }
+
+    private void FfiEnumExists(CTestFfiTargetPlatform ffi)
+    {
+        var @enum = ffi.GetEnum("enum_implicit");
+        @enum.Values.Should().HaveCount(2);
+        @enum.SizeOf.Should().Be(4);
+    }
+}

--- a/src/cs/tests/c2ffi.Tests.EndToEnd.Merge/Functions/function_implicit_enum/Test.cs
+++ b/src/cs/tests/c2ffi.Tests.EndToEnd.Merge/Functions/function_implicit_enum/Test.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Bottlenose Labs Inc. (https://github.com/bottlenoselabs). All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the Git repository root directory for full license information.
+
+#pragma warning disable CA1707
+
+namespace c2ffi.Tests.EndToEnd.Merge.Functions.function_implicit_enum;
+
+public class Test : MergeFfisTest
+{
+    private const string FunctionName = "function_implicit_enum";
+
+    [Fact]
+    public void Function()
+    {
+        var ffi = GetCrossPlatformFfi(
+            $"src/c/tests/functions/{FunctionName}/ffi");
+
+        FfiFunctionExists(ffi);
+        FfiEnumExists(ffi);
+    }
+
+    private void FfiFunctionExists(CTestFfiCrossPlatform ffi)
+    {
+        var function = ffi.GetFunction(FunctionName);
+        function.CallingConvention.Should().Be("cdecl");
+
+        var returnType = function.ReturnType;
+        returnType.Name.Should().Be("int");
+        returnType.NodeKind.Should().Be("primitive");
+        returnType.SizeOf.Should().Be(4);
+        returnType.AlignOf.Should().Be(4);
+        returnType.InnerType.Should().BeNull();
+
+        function.Parameters.Should().HaveCount(1);
+        var parameter = function.Parameters[0];
+        parameter.Name.Should().Be("value");
+        parameter.Type.Name.Should().Be("int");
+        parameter.Type.NodeKind.Should().Be("primitive");
+        parameter.Type.SizeOf.Should().Be(4);
+        parameter.Type.AlignOf.Should().Be(4);
+
+        var @enum = ffi.GetEnum("enum_implicit");
+        @enum.Values.Should().HaveCount(2);
+        @enum.SizeOf.Should().Be(4);
+    }
+
+    private void FfiEnumExists(CTestFfiCrossPlatform ffi)
+    {
+        var @enum = ffi.GetEnum("enum_implicit");
+        @enum.Values.Should().HaveCount(2);
+        @enum.SizeOf.Should().Be(4);
+    }
+}


### PR DESCRIPTION
In the context of SDL, there is sometimes the following case:

```c
/**
 * The predefined log priorities
 *
 * \since This enum is available since SDL 3.0.0.
 */
typedef enum SDL_LogPriority
{
    SDL_LOG_PRIORITY_VERBOSE = 1,
    SDL_LOG_PRIORITY_DEBUG,
    SDL_LOG_PRIORITY_INFO,
    SDL_LOG_PRIORITY_WARN,
    SDL_LOG_PRIORITY_ERROR,
    SDL_LOG_PRIORITY_CRITICAL,
    SDL_NUM_LOG_PRIORITIES
} SDL_LogPriority;
...
extern DECLSPEC SDL_LogPriority SDLCALL SDL_LogGetPriority(int category);
```

The API is defined as passing a `SDL_LogPriority` to the function `SDL_LogGetPriority` even if it's not directly referenced by type in the function parameter.

This code allows to manually pass in the names of enums to be included in the `config.json`:
```json
  "includedNames": [
    "enum_name"
  ],
```