### PR TITLE
Fixes 1.3.2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Note that the internals of the C library is irrelevant and to which this list do
 |❌|Function-like macros <sup>5</sup>|
 |✅|Object-like macros <sup>2, 6, 7</sup>|
 
-<sup>1</sup>: When declaring your external functions or variables, do set the default visibility explictly. This is necessary because `c2ffi` is configured to have the visbiity set to hidden so that only the strict subset of functions and variables intended for FFI are extracted. Most C libraries will have an `API_DECL` macro object defined which can be redefined to also set the visibility. See [ffi_helper.h](src/c/production/ffi_helper/include/ffi_helper.h) for an example.
+<sup>1</sup>: When declaring your external functions or variables, do set the default visibility explictly. This is necessary because `c2ffi` is configured to have the visibiity set to hidden when using `libclang` via the flag `-fvisibility=hidden` so that only the strict subset of functions and variables intended for FFI are extracted. Most C libraries will have an `API_DECL` macro object defined which can be redefined to also set the visibility. See [ffi_helper.h](src/c/production/ffi_helper/include/ffi_helper.h) for an example in C. You can also use the config `.json` file to define tyour `API_DECL` macro object.
 
 Bad
 ```c

--- a/src/c/tests/functions/function_internal/config.json
+++ b/src/c/tests/functions/function_internal/config.json
@@ -4,11 +4,11 @@
     "../../../production/ffi_helper/include"
   ],
   "defines": {
-    "BAD_CUSTOM_API_DECL": "extern",
+    "BAD_CUSTOM_API_DECL": "",
     "GOOD_CUSTOM_API_DECL": "extern __attribute__ ((visibility(\"default\")))"
   },
   "ignoredIncludeFiles": [
-    "../../../production/ffi_helper/include/ffi_helper.h"
+    "./include.h"
   ],
     "targetPlatforms": {
     "windows": {

--- a/src/c/tests/functions/function_internal/include.h
+++ b/src/c/tests/functions/function_internal/include.h
@@ -1,0 +1,6 @@
+#include <stdio.h>
+#include "ffi_helper.h"
+
+void function_internal_1()
+{
+}

--- a/src/c/tests/functions/function_internal/main.c
+++ b/src/c/tests/functions/function_internal/main.c
@@ -1,9 +1,6 @@
 #include <stdio.h>
 #include "ffi_helper.h"
-
-void function_internal_1()
-{
-}
+#include "include.h"
 
 FFI_API_DECL void function_internal_2()
 {

--- a/src/cs/production/c2ffi.Data/CLocation.cs
+++ b/src/cs/production/c2ffi.Data/CLocation.cs
@@ -75,7 +75,7 @@ public record struct CLocation : IComparable<CLocation>
     }
 
     /// <inheritdoc />
-    public override readonly string ToString()
+    public readonly override string ToString()
     {
         if (LineNumber == 0 && LineColumn == 0)
         {

--- a/src/cs/production/c2ffi.Data/CLocation.cs
+++ b/src/cs/production/c2ffi.Data/CLocation.cs
@@ -75,7 +75,8 @@ public record struct CLocation : IComparable<CLocation>
     }
 
     /// <inheritdoc />
-    public readonly override string ToString()
+    // ReSharper disable once ArrangeModifiersOrder
+    public override readonly string ToString()
     {
         if (LineNumber == 0 && LineColumn == 0)
         {

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/ExploreContext.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/ExploreContext.cs
@@ -30,7 +30,7 @@ internal sealed class ExploreContext(
     public void TryEnqueueNode(NodeInfo info)
     {
         var handler = GetHandler(info.NodeKind);
-        if (!handler.CanVisitInternal(this, info))
+        if (!handler.CanVisitInternal(info))
         {
             return;
         }
@@ -140,7 +140,7 @@ internal sealed class ExploreContext(
         NodeInfo? rootNode)
     {
         var clangCursorLocation = clang.clang_getTypeDeclaration(clangType);
-        var location = ParseContext.Location(clangCursorLocation);
+        var location = ParseContext.Location(clangCursorLocation, out _);
 
         int? sizeOf;
         int? alignOf;
@@ -281,7 +281,7 @@ internal sealed class ExploreContext(
         clang.CXType clangType,
         NodeInfo? parentInfo)
     {
-        var location = ParseContext.Location(clangCursor);
+        var location = ParseContext.Location(clangCursor, out _);
         var sizeOf = ParseContext.SizeOf(kind, clangType);
         var alignOf = ParseContext.AlignOf(kind, clangType);
 

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/Explorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/Explorer.cs
@@ -73,7 +73,7 @@ public sealed partial class Explorer(
 
     private void VisitFunctions(ExploreContext exploreContext, ParseContext parseContext)
     {
-        var functionCursors = parseContext.GetExternalFunctions();
+        var functionCursors = parseContext.GetExternalFunctions(parseContext);
         foreach (var cursor in functionCursors)
         {
             VisitFunction(exploreContext, cursor);

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/Explorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/Explorer.cs
@@ -168,6 +168,7 @@ public sealed partial class Explorer(
         {
             if (filePath.Contains(systemIncludeDirectory, StringComparison.InvariantCulture))
             {
+                LogSkippedSystemInclude(filePath);
                 return;
             }
         }
@@ -257,4 +258,7 @@ public sealed partial class Explorer(
 
     [LoggerMessage(8, LogLevel.Debug, "- Skipping already visited include file header: {FilePath}")]
     private partial void LogAlreadyVisitedInclude(string filePath);
+
+    [LoggerMessage(9, LogLevel.Debug, "- Skipping system include file header: {FilePath}")]
+    private partial void LogSkippedSystemInclude(string filePath);
 }

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorer.cs
@@ -44,7 +44,7 @@ internal abstract partial class NodeExplorer(
         return result;
     }
 
-    internal bool CanVisitInternal(ExploreContext exploreContext, NodeInfo info)
+    internal bool CanVisitInternal(NodeInfo info)
     {
         if (!IsExpectedCursor(info))
         {
@@ -73,22 +73,11 @@ internal abstract partial class NodeExplorer(
             return false;
         }
 
-        if (!IsIgnored(exploreContext, info))
-        {
-            LogIgnored(info.NodeKind.ToString(), info.Name);
-            return false;
-        }
-
         MarkAsVisited(info);
         return true;
     }
 
     protected abstract CNode? GetNode(ExploreContext exploreContext, NodeInfo info);
-
-    protected virtual bool IsIgnored(ExploreContext exploreContext, NodeInfo info)
-    {
-        return true;
-    }
 
     private bool IsAlreadyVisited(NodeInfo info, out CLocation? firstLocation)
     {
@@ -130,6 +119,6 @@ internal abstract partial class NodeExplorer(
     [LoggerMessage(5, LogLevel.Debug, "- Explored {Kind} '{Name}' ({Location})'")]
     private partial void LogExplored(string kind, string name, CLocation? location);
 
-    [LoggerMessage(6, LogLevel.Debug, "- Ignored {Kind} '{Name}'")]
-    private partial void LogIgnored(string kind, string name);
+    [LoggerMessage(6, LogLevel.Information, "- Tried to explore {Kind} '{Name}' ({Location})' but failed.")]
+    private partial void LogNotExplored(string kind, string name, CLocation? location);
 }

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/FunctionExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/FunctionExplorer.cs
@@ -29,20 +29,6 @@ internal sealed class FunctionExplorer(ILogger<FunctionExplorer> logger)
     protected override KindTypes ExpectedTypes { get; } = KindTypes.Either(
         CXTypeKind.CXType_FunctionProto, CXTypeKind.CXType_FunctionNoProto);
 
-    protected override bool IsIgnored(ExploreContext exploreContext, NodeInfo info)
-    {
-        var regexes = exploreContext.ParseContext.InputSanitized.IgnoredFunctionRegexes;
-        foreach (var regex in regexes)
-        {
-            if (regex.IsMatch(info.Name))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     protected override CNode GetNode(ExploreContext exploreContext, NodeInfo info)
     {
         var function = Function(exploreContext, info);

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/MacroObjectExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/MacroObjectExplorer.cs
@@ -30,20 +30,6 @@ internal sealed class MacroObjectExplorer(
 
     protected override KindTypes ExpectedTypes => KindTypes.Any;
 
-    protected override bool IsIgnored(ExploreContext exploreContext, NodeInfo info)
-    {
-        var ignoredMacroObjectRegexes = exploreContext.ParseContext.InputSanitized.IgnoredMacroObjectsRegexes;
-        foreach (var regex in ignoredMacroObjectRegexes)
-        {
-            if (regex.IsMatch(info.Name))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     protected override CNode? GetNode(ExploreContext exploreContext, NodeInfo info)
     {
         return MacroObject(exploreContext, info);
@@ -250,7 +236,7 @@ int main(void)
             clang.CXCursor clangCursor)
         {
             var name = clangCursor.Spelling();
-            var location = parseContext.Location(clangCursor);
+            var location = parseContext.Location(clangCursor, out _);
 
             // clang doesn't have a thing where we can easily get a value of a macro
             // we need to:

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/StructExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/StructExplorer.cs
@@ -72,7 +72,7 @@ internal sealed class StructExplorer(ILogger<StructExplorer> logger) : RecordExp
     {
         var fieldName = exploreContext.GetFieldName(clangCursor);
         var clangType = clang_getCursorType(clangCursor);
-        var location = exploreContext.ParseContext.Location(clangCursor);
+        var location = exploreContext.ParseContext.Location(clangCursor, out _);
         var type = exploreContext.VisitType(clangType, structInfo);
         var offsetOf = (int)clang_Cursor_getOffsetOfField(clangCursor) / 8;
         var comment = exploreContext.Comment(clangCursor);

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/UnionExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/UnionExplorer.cs
@@ -70,7 +70,7 @@ internal sealed class UnionExplorer(ILogger<UnionExplorer> logger) : RecordExplo
     {
         var name = exploreContext.GetFieldName(clangCursor);
         var clangType = clang_getCursorType(clangCursor);
-        var location = exploreContext.ParseContext.Location(clangCursor);
+        var location = exploreContext.ParseContext.Location(clangCursor, out _);
         var type = exploreContext.VisitType(clangType, parentInfo);
         var comment = exploreContext.Comment(clangCursor);
 

--- a/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/VariableExplorer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Explore/NodeExplorers/VariableExplorer.cs
@@ -19,20 +19,6 @@ internal sealed class VariableExplorer(ILogger<VariableExplorer> logger)
 
     protected override KindTypes ExpectedTypes => KindTypes.Any;
 
-    protected override bool IsIgnored(ExploreContext exploreContext, NodeInfo info)
-    {
-        var regexes = exploreContext.ParseContext.InputSanitized.IgnoredVariableRegexes;
-        foreach (var regex in regexes)
-        {
-            if (regex.IsMatch(info.Name))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
     protected override CNode GetNode(ExploreContext exploreContext, NodeInfo info)
     {
         return Variable(exploreContext, info);

--- a/src/cs/production/c2ffi.Tool/Extract/InputSanitizedTargetPlatform.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/InputSanitizedTargetPlatform.cs
@@ -29,11 +29,11 @@ public sealed class InputSanitizedTargetPlatform
 
     public ImmutableHashSet<string> IncludedNames { get; init; } = ImmutableHashSet<string>.Empty;
 
-    public ImmutableArray<Regex> IgnoredMacroObjectsRegexes { get; init; } = ImmutableArray<Regex>.Empty;
+    public ImmutableArray<Regex> IgnoreMacroObjectsRegexes { get; init; } = ImmutableArray<Regex>.Empty;
 
-    public ImmutableArray<Regex> IgnoredVariableRegexes { get; init; } = ImmutableArray<Regex>.Empty;
+    public ImmutableArray<Regex> IgnoreVariableRegexes { get; init; } = ImmutableArray<Regex>.Empty;
 
-    public ImmutableArray<Regex> IgnoredFunctionRegexes { get; init; } = ImmutableArray<Regex>.Empty;
+    public ImmutableArray<Regex> IgnoreFunctionRegexes { get; init; } = ImmutableArray<Regex>.Empty;
 
     public override string ToString()
     {

--- a/src/cs/production/c2ffi.Tool/Extract/InputSanitizer.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/InputSanitizer.cs
@@ -121,9 +121,9 @@ public sealed class InputSanitizer(IFileSystem fileSystem) : InputSanitizer<Inpu
             IsEnabledFindSystemHeaders = input.IsEnabledAutomaticallyFindSystemHeaders ?? true,
             IsSingleHeader = input.IsSingleHeader ?? false,
             IncludedNames = IncludedNames(input),
-            IgnoredMacroObjectsRegexes = IgnoredMacroObjects(input),
-            IgnoredVariableRegexes = IgnoredVariables(input),
-            IgnoredFunctionRegexes = IgnoredFunctions(input)
+            IgnoreMacroObjectsRegexes = IgnoredMacroObjects(input),
+            IgnoreVariableRegexes = IgnoredVariables(input),
+            IgnoreFunctionRegexes = IgnoredFunctions(input)
         };
 
         return options;

--- a/src/cs/production/c2ffi.Tool/Extract/Parse/ParseArgumentsProvider.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Parse/ParseArgumentsProvider.cs
@@ -84,7 +84,7 @@ public sealed class ParseArgumentsProvider
 
         // Change the default visibility of symbols (functions, variables, etc.) from default to hidden
         //  This makes it so we don't extract symbols that are not explicitly set to default
-        args.Add("-fvisibility=hidden");
+        args.Add("-fvisibility-ms-compat");
     }
 
     private void AddIgnoreWarnings(ImmutableArray<string>.Builder args)

--- a/src/cs/production/c2ffi.Tool/Extract/Parse/ParseSystemIncludeDirectoriesProvider.cs
+++ b/src/cs/production/c2ffi.Tool/Extract/Parse/ParseSystemIncludeDirectoriesProvider.cs
@@ -158,8 +158,12 @@ public sealed partial class ParseSystemIncludeDirectoriesProvider(
             + " Do you need install the software development kit for Windows? https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk/");
         }
 
-        var systemIncludeCommandLineArgSdk = $@"{sdkHighestVersionDirectoryPath}\ucrt";
-        directories.Add(systemIncludeCommandLineArgSdk);
+        // e.g. ucrt, shared, etc
+        var sdkDirectoryPaths = fileSystem.Directory.EnumerateDirectories(sdkHighestVersionDirectoryPath);
+        foreach (var directoryPath in sdkDirectoryPaths)
+        {
+            directories.Add(directoryPath);
+        }
 
         var vsWhereFilePath =
             Environment.ExpandEnvironmentVariables(


### PR DESCRIPTION
- Fix macro object types sometimes returning an invalid Clang type.
- Fix Windows default directories for system types.
- Move regex logic up closer to time of Clang AST thus simplifying the overall logic.
